### PR TITLE
0.5.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ build:
   number: 0
   skip: true  # [py<36 or (win and rust_compiler == "rust-gnu")]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  missing_dso_whitelist:
+    - '$RPATH/ld64.so.1'  # [linux-s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,19 @@
 {% set name = "dbt-extractor" %}
-{% set version = "0.4.1" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dbt_extractor-{{ version }}.tar.gz
+  git_url: https://github.com/dbt-labs/{{ name }}.git
+  # Based on https://github.com/dbt-labs/dbt-extractor/actions/runs/5650153364.
+  ref: 83f0d93d4d5537de3960ac5659f72f430f5d7d5d
   sha256: 75b1c665699ec0f1ffce1ba3d776f7dfce802156f22e70a7b9c8f0b4d7e80f42
 
 build:
   number: 0
-  # maturin isn't availabe on s390x.
-  skip: true  # [py<36 or s390x or (win and rust_compiler == "rust-gnu")]
+  skip: true  # [py<36 or (win and rust_compiler == "rust-gnu")]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -20,7 +21,6 @@ requirements:
     # The C compiler is required because of missing libgcc-ng on linux
     - {{ compiler('c') }}  # [linux]
     - {{ compiler('rust') }}
-    - maturin
   host:
     - maturin
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   skip: true  # [py<36 or (win and rust_compiler == "rust-gnu")]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:
-    - '$RPATH/ld64.so.1'  # [linux-s390x]
+    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     # The C compiler is required because of missing libgcc-ng on linux
     - {{ compiler('c') }}  # [linux]
     - {{ compiler('rust') }}
+    - git  # [not win]
   host:
     - maturin
     - pip


### PR DESCRIPTION
Update to 0.5.0 for latest dbt.

Upstream: https://github.com/dbt-labs/dbt-extractor

Note that they didn't create a tag and they didn't upload an sdist on PyPI. I created https://github.com/dbt-labs/dbt-extractor/issues/71 to let them know what we would ike to at least have an sdist.