### PR TITLE
remove snowflake channel, bump up build number

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 75b1c665699ec0f1ffce1ba3d776f7dfce802156f22e70a7b9c8f0b4d7e80f42
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<36 or (win and rust_compiler == "rust-gnu")]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:


### PR DESCRIPTION
remove snowflake channel, bump up build number in order to push it to defaults