### PR TITLE
Bump build number. Build with rust 1.82

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 75b1c665699ec0f1ffce1ba3d776f7dfce802156f22e70a7b9c8f0b4d7e80f42
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<36 or (win and rust_compiler == "rust-gnu")]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6212](https://anaconda.atlassian.net/browse/PKG-6212)
 
### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.

[PKG-6212]: https://anaconda.atlassian.net/browse/PKG-6212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ